### PR TITLE
Fix pixel widths.  Also fix running on CPU

### DIFF
--- a/Loader.py
+++ b/Loader.py
@@ -44,13 +44,13 @@ class Dataset(data.Dataset):
             if(w > h):
                 if(w != self.fineSize):
                     neww = self.fineSize
-                    newh = h*neww/w
+                    newh = int(h*neww/w)
                     contentImg = contentImg.resize((neww,newh))
                     styleImg = styleImg.resize((neww,newh))
             else:
                 if(h != self.fineSize):
                     newh = self.fineSize
-                    neww = w*newh/h
+                    neww = int(w*newh/h)
                     contentImg = contentImg.resize((neww,newh))
                     styleImg = styleImg.resize((neww,newh))
 


### PR DESCRIPTION
…d of float for width.

Problem:  in python 3.6 (my version anyway, anaconda), a fixed point division is resulting in
a floating point result, which then causes an error in image resizing computations.  This
patch simply casts the results to int before passing to resize.